### PR TITLE
fix: config resolution, -c exec mode and df rule (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: user conf files on disk now override embedded configs again; embedded is the last resort (#23)
+- fix: disk mapper and conf files now override the embedded ones; embedded is the last resort for both (#23)
 - feat: `rgrc -c NAME COMMAND [ARGS...]` runs the command instead of blocking on stdin; `-c` also accepts conf file names like `conf.df` (#23)
 - feat: honor XDG_CONFIG_HOME/XDG_DATA_HOME/XDG_CONFIG_DIRS/XDG_DATA_DIRS for config lookup (#23)
 - feat: dev paths `share/` and `etc/rgrc.conf` are only searched with RGRC_DEV_SHARE set (#23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- fix: user conf files on disk now override embedded configs again; embedded is the last resort (#23)
+- feat: `rgrc -c NAME COMMAND [ARGS...]` runs the command instead of blocking on stdin; `-c` also accepts conf file names like `conf.df` (#23)
+- feat: honor XDG_CONFIG_HOME/XDG_DATA_HOME/XDG_CONFIG_DIRS/XDG_DATA_DIRS for config lookup (#23)
+- feat: dev paths `share/` and `etc/rgrc.conf` are only searched with RGRC_DEV_SHARE set (#23)
+- feat: rgrc.conf patterns match the full command line first, then the bare command name (#23)
+- perf: drop the unnecessary lookahead in conf.df so it stays on the fast regex path (#23)
+
 ## v0.6.20
 
 - feat: support 256-color and truecolor in config files via `colour_N`, `rgb:RRGGBB`, and raw ANSI escape strings

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Options:
   --all-aliases        Output all shell aliases
   --except CMD,..      Exclude commands from alias generation
   --completions SHELL  Print shell completion script for SHELL (bash|zsh|fish|ash)
-  --config, -c NAME    Explicit config file name (e.g., df to load conf.df)
+  --config, -c NAME    Explicit config (df or conf.df); with a COMMAND runs it
   --help, -h           Show this help message
   --version, -V        Show installed rgrc version and exit
 ```

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default: on
+    patch: false

--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -10,9 +10,28 @@
    ```
 3. Test with:
    ```bash
-   echo "ERROR: Something went wrong" | cargo run --  -c conf.mycommand
+   echo "ERROR: Something went wrong" | RGRC_DEV_SHARE=1 cargo run -- --color on -c conf.mycommand
    ```
-4. Enable command in `src/rgrc.conf` to load the new config file. after that, the command will be available as `rgrc mycommand` (or via alias if configured).
+   `RGRC_DEV_SHARE=1` makes rgrc search `share/` next to the repo; without it
+   only user (`$XDG_CONFIG_HOME/rgrc`) and system paths are searched.
+   `-c` also runs a command when one is given:
+   ```bash
+   RGRC_DEV_SHARE=1 cargo run -- --color on -c conf.mycommand mycommand --arg
+   ```
+4. Enable command in `etc/rgrc.conf` to load the new config file. after that, the command will be available as `rgrc mycommand` (or via alias if configured).
+
+## Config resolution
+
+Conf files are searched in this order (first match wins, embedded configs last):
+
+1. `$XDG_CONFIG_HOME/rgrc` (default `~/.config/rgrc`)
+2. `$XDG_DATA_HOME/rgrc` (default `~/.local/share/rgrc`)
+3. `$XDG_CONFIG_DIRS/rgrc`, `$XDG_DATA_DIRS/rgrc` (system defaults apply)
+4. grc compat paths (`~/.config/grc`, `/usr/share/grc`, ...)
+5. configs embedded at build time
+
+Mapper files (`rgrc.conf`) are searched the same way. Patterns match the full
+command line first, then the bare command name, so `^df$` also matches `df -h`.
 
 ## Testing
 

--- a/share/conf.df
+++ b/share/conf.df
@@ -1,6 +1,6 @@
 # FS
 #regexp=^.*?\s
-regexp=^(?!Filesystem)(\/[-\w\d.]+)+\s
+regexp=^(\/[-\w\d.]+)+\s
 colours=blue,bold blue
 ======
 # Size 'K'

--- a/src/args.rs
+++ b/src/args.rs
@@ -249,7 +249,7 @@ fn print_help() {
     println!("  --except CMD,..      Exclude commands from alias generation");
     println!("  --completions SHELL  Print shell completion script for SHELL (bash|zsh|fish|ash)");
     #[cfg(feature = "embed-configs")]
-    println!("  --config, -c NAME    Explicit config file name (e.g., df to load conf.df)");
+    println!("  --config, -c NAME    Explicit config (df or conf.df); with a COMMAND runs it");
     println!("  --help, -h           Show this help message");
     println!("  --version, -V        Show installed rgrc version and exit");
     println!();
@@ -258,8 +258,9 @@ fn print_help() {
     println!("  rgrc --color=off ls -la");
     println!("  rgrc --aliases");
     println!();
-    println!("  echo 'some text' | rgrc -c df  # Apply df config to piped input");
-    println!("  /bin/df | rgrc --config=df     # Colorize output using explicit config");
+    println!("  df -h | rgrc -c df          # Apply df config to piped input");
+    println!("  rgrc -c df df -h            # Run df -h and colorize with conf.df");
+    println!("  rgrc -c conf.myapp myapp    # Use an explicit conf file");
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,8 @@ fn xdg_data_home() -> PathBuf {
 
 fn xdg_dirs(var: &str, default: &str) -> Vec<PathBuf> {
     let raw = std::env::var_os(var)
+        // an empty value behaves as unset, so the defaults still apply
+        .filter(|v| !v.is_empty())
         .map(|v| v.to_string_lossy().into_owned())
         .unwrap_or_else(|| default.to_string());
     raw.split(':')
@@ -278,24 +280,17 @@ pub fn load_grcat_config<T: AsRef<str>>(filename: T) -> Vec<GrcatConfigEntry> {
 
 /// Load colorization rules for a given pseudo-command by searching all
 /// configuration paths. The search stops at the first mapper file that yields
-/// rules. Priority: user mapper (`$XDG_CONFIG_HOME/rgrc/rgrc.conf`), the
-/// embedded mapper (its conf files still resolve disk paths first), then the
-/// remaining mapper paths ending with legacy grc locations.
+/// rules. Priority: user mapper (`$XDG_CONFIG_HOME/rgrc/rgrc.conf`), then
+/// the remaining mapper paths ending with legacy grc locations; the embedded
+/// mapper is the last resort.
 ///
 /// * `pseudo_command` - the command string to match, including arguments
-///   (e.g. "ping", "df -h"); a second pass matches the bare command name
+///   ("ping", "df -h"); a second pass matches the bare command name
 pub fn load_rules_for_command(pseudo_command: &str) -> Vec<GrcatConfigEntry> {
     // Always prioritize the user mapper
     let user_config = xdg_config_home().join("rgrc/rgrc.conf");
     let rules = load_config(&user_config.to_string_lossy(), pseudo_command);
     if !rules.is_empty() {
-        return rules;
-    }
-
-    // embedded mapper; the conf files it references still resolve user
-    // paths on disk before falling back to the embedded copies
-    #[cfg(feature = "embed-configs")]
-    if let Some(rules) = load_embedded(pseudo_command) {
         return rules;
     }
 
@@ -307,6 +302,12 @@ pub fn load_rules_for_command(pseudo_command: &str) -> Vec<GrcatConfigEntry> {
         if !rules.is_empty() {
             return rules;
         }
+    }
+
+    // embedded mapper only after every disk mapper failed to match
+    #[cfg(feature = "embed-configs")]
+    if let Some(rules) = load_embedded(pseudo_command) {
+        return rules;
     }
 
     Vec::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,19 +13,10 @@ pub mod utils;
 
 use std::fs::File;
 use std::io::BufRead;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use grc::{GrcConfigReader, GrcatConfigEntry, GrcatConfigReader};
-
-// Simple tilde expansion function to replace shellexpand
-fn expand_tilde(path: &str) -> String {
-    if let Some(stripped) = path.strip_prefix("~/")
-        && let Ok(home) = std::env::var("HOME")
-    {
-        return format!("{}/{}", home, stripped);
-    }
-    path.to_string()
-}
 
 // Use generated `embedded_configs.rs` (created by build.rs) so the list of
 // embedded files is derived from the `share` directory instead of being hard-coded.
@@ -80,98 +71,177 @@ impl FromStr for ColorMode {
     }
 }
 
-/// Search paths for conf files, user config first, system/legacy last.
-pub const RESOURCE_PATHS: &[&str] = &[
-    "share", // Development mode: relative to project root (where cargo run is executed)
-    "~/.config/rgrc",
-    "~/.local/share/rgrc",
-    "/usr/local/share/rgrc",
-    "/usr/share/rgrc",
-    "~/.config/grc",
-    "~/.local/share/grc",
-    "/usr/local/share/grc",
-    "/usr/share/grc",
-];
-
-/// Load rules for `pseudo_command` by matching it against grc.conf patterns,
-/// then reading the referenced conf file from the first matching RESOURCE_PATHS.
-/// Returns empty vec on any failure (file not found, no match, parse error).
-pub fn load_config(path: &str, pseudo_command: &str) -> Vec<GrcatConfigEntry> {
-    // First, try to load from filesystem config file
-    let filesystem_result = File::open(path).ok().and_then(|f| {
-        let bufreader = std::io::BufReader::new(f);
-        let configreader = GrcConfigReader::new(bufreader.lines());
-        // Iterate each rule so we can optionally log which pattern matched
-        for (re, config) in configreader {
-            if re.is_match(pseudo_command) {
-                if std::env::var_os("RGRC_DEBUG").is_some() {
-                    eprintln!(
-                        "rgrc: matched pattern '{}' in {} for '{}'",
-                        re.as_str(),
-                        path,
-                        pseudo_command
-                    );
-                }
-                return Some(config);
-            }
-        }
-        None
-    });
-
-    if let Some(config) = filesystem_result {
-        // Search RESOURCE_PATHS for the colorization file - **stop at first match**
-        for base_path in RESOURCE_PATHS {
-            let expanded_path = expand_tilde(base_path);
-            let config_path = format!("{}/{}", expanded_path, config);
-            if std::env::var_os("RGRC_DEBUG").is_some() {
-                eprintln!("rgrc: checking for config file {}", config_path);
-            }
-            // Use file_exists_and_parse to distinguish "file exists but empty" from "file not found"
-            match file_exists_and_parse(&config_path) {
-                Some(rules) => {
-                    if std::env::var_os("RGRC_DEBUG").is_some() {
-                        eprintln!(
-                            "rgrc: found config file {} ({} rules)",
-                            config_path,
-                            rules.len()
-                        );
-                    }
-                    return rules; // File found (even if empty) - STOP
-                }
-                None => continue, // File not found - keep searching
-            }
-        }
-    }
-
-    // No configuration found
-    Vec::new()
+fn home() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|h| !h.as_os_str().is_empty())
 }
 
-/// Check if a file exists and parse it for colorization rules.
-///
-/// Returns:
-/// - `Some(rules)` if file exists (may be empty if file is empty)
-/// - `None` if file does not exist
-///
-/// This distinguishes between "file doesn't exist" (None) and
-/// "file exists but has no rules" (Some([])).
-fn file_exists_and_parse(filename: &str) -> Option<Vec<GrcatConfigEntry>> {
-    if let Ok(grcat_config_file) = File::open(filename) {
-        let bufreader = std::io::BufReader::new(grcat_config_file);
-        let configreader = GrcatConfigReader::new(bufreader.lines());
-        let entries: Vec<_> = configreader.collect();
-        return Some(entries);
+// XDG base directory spec: relative values are ignored, fall back to defaults
+fn xdg_config_home() -> PathBuf {
+    match std::env::var_os("XDG_CONFIG_HOME") {
+        Some(v) if Path::new(&v).is_absolute() => PathBuf::from(v),
+        _ => home()
+            .map(|h| h.join(".config"))
+            .unwrap_or_else(|| PathBuf::from(".config")),
+    }
+}
+
+fn xdg_data_home() -> PathBuf {
+    match std::env::var_os("XDG_DATA_HOME") {
+        Some(v) if Path::new(&v).is_absolute() => PathBuf::from(v),
+        _ => home()
+            .map(|h| h.join(".local/share"))
+            .unwrap_or_else(|| PathBuf::from(".local/share")),
+    }
+}
+
+fn xdg_dirs(var: &str, default: &str) -> Vec<PathBuf> {
+    let raw = std::env::var_os(var)
+        .map(|v| v.to_string_lossy().into_owned())
+        .unwrap_or_else(|| default.to_string());
+    raw.split(':')
+        .filter(|p| Path::new(p).is_absolute())
+        .map(PathBuf::from)
+        .collect()
+}
+
+// development paths next to the repo are only searched when opted in,
+// otherwise a stray share/ in the cwd would shadow user configs (#23)
+fn dev_paths_enabled() -> bool {
+    std::env::var_os("RGRC_DEV_SHARE").is_some()
+}
+
+fn dedup(paths: &mut Vec<PathBuf>) {
+    let mut seen = std::collections::HashSet::new();
+    paths.retain(|p| seen.insert(p.clone()));
+}
+
+/// Search paths for conf files, user config first, system/legacy last.
+/// Honors the XDG base directory environment variables; grc paths are kept
+/// for compatibility. The development `share/` dir requires RGRC_DEV_SHARE.
+pub fn resource_paths() -> Vec<PathBuf> {
+    let mut paths = vec![xdg_config_home().join("rgrc"), xdg_data_home().join("rgrc")];
+    paths.extend(
+        xdg_dirs("XDG_CONFIG_DIRS", "/etc/xdg")
+            .into_iter()
+            .map(|d| d.join("rgrc")),
+    );
+    paths.extend(
+        xdg_dirs("XDG_DATA_DIRS", "/usr/local/share:/usr/share")
+            .into_iter()
+            .map(|d| d.join("rgrc")),
+    );
+    if let Some(h) = home() {
+        paths.push(h.join(".config/grc"));
+        paths.push(h.join(".local/share/grc"));
+    }
+    paths.push(PathBuf::from("/usr/local/share/grc"));
+    paths.push(PathBuf::from("/usr/share/grc"));
+    if dev_paths_enabled() {
+        paths.insert(0, PathBuf::from("share"));
+    }
+    dedup(&mut paths);
+    paths
+}
+
+/// Mapper file (rgrc.conf / grc.conf) locations, user first, then system,
+/// then grc legacy. The development `etc/rgrc.conf` requires RGRC_DEV_SHARE.
+fn config_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if dev_paths_enabled() {
+        paths.push(PathBuf::from("etc/rgrc.conf"));
+    }
+    if let Some(h) = home() {
+        paths.push(h.join(".rgrc"));
+    }
+    paths.push(xdg_config_home().join("rgrc/rgrc.conf"));
+    paths.extend(
+        xdg_dirs("XDG_CONFIG_DIRS", "/etc/xdg")
+            .into_iter()
+            .map(|d| d.join("rgrc/rgrc.conf")),
+    );
+    paths.push(PathBuf::from("/usr/local/etc/rgrc.conf"));
+    paths.push(PathBuf::from("/etc/rgrc.conf"));
+    if let Some(h) = home() {
+        paths.push(h.join(".grc"));
+    }
+    paths.push(xdg_config_home().join("grc/grc.conf"));
+    paths.push(PathBuf::from("/usr/local/etc/grc.conf"));
+    paths.push(PathBuf::from("/etc/grc.conf"));
+    dedup(&mut paths);
+    paths
+}
+
+/// Load rules for `pseudo_command` by matching it against the patterns in the
+/// mapper file at `path`, then reading the referenced conf file from the first
+/// matching resource path. Embedded configs are the last resort so that user
+/// files on disk always win. Returns empty vec on any failure.
+pub fn load_config(path: &str, pseudo_command: &str) -> Vec<GrcatConfigEntry> {
+    let patterns = {
+        let file = match File::open(path) {
+            Ok(f) => f,
+            Err(_) => return Vec::new(),
+        };
+        let reader = GrcConfigReader::new(std::io::BufReader::new(file).lines());
+        reader.collect::<Vec<_>>()
+    };
+
+    // two-pass match: the full pseudo command first (patterns can require
+    // args), then the bare command name so simple rules like ^df$ also work
+    let cmd_name = pseudo_command
+        .split_whitespace()
+        .next()
+        .unwrap_or(pseudo_command);
+    let conf = patterns
+        .iter()
+        .find(|(re, _)| re.is_match(pseudo_command))
+        .or_else(|| patterns.iter().find(|(re, _)| re.is_match(cmd_name)))
+        .map(|(_, c)| c.clone());
+    let Some(conf) = conf else {
+        return Vec::new();
+    };
+    if std::env::var_os("RGRC_DEBUG").is_some() {
+        eprintln!("rgrc: matched conf '{}' for '{}'", conf, pseudo_command);
+    }
+
+    conf_rules(&conf)
+}
+
+/// Resolve a conf name like "conf.df" to rules: first matching disk resource
+/// path wins (an empty file stops the search), embedded configs last.
+fn conf_rules(conf: &str) -> Vec<GrcatConfigEntry> {
+    for base in resource_paths() {
+        let conf_path = base.join(conf);
+        if std::env::var_os("RGRC_DEBUG").is_some() {
+            eprintln!("rgrc: checking for config file {}", conf_path.display());
+        }
+        if let Some(rules) = read_conf_file(&conf_path) {
+            if std::env::var_os("RGRC_DEBUG").is_some() {
+                eprintln!(
+                    "rgrc: found config file {} ({} rules)",
+                    conf_path.display(),
+                    rules.len()
+                );
+            }
+            return rules;
+        }
     }
 
     #[cfg(feature = "embed-configs")]
-    {
-        let name = basename(filename);
-        if let Some(entries) = parse_embedded_conf(name) {
-            return Some(entries);
-        }
+    if let Some(entries) = parse_embedded_conf(conf) {
+        return entries;
     }
 
-    None
+    Vec::new()
+}
+
+/// Read a grcat conf file from disk. `Some(rules)` if the file exists (an
+/// empty file yields `Some([])`), `None` when missing.
+fn read_conf_file(path: &Path) -> Option<Vec<GrcatConfigEntry>> {
+    let file = File::open(path).ok()?;
+    let reader = GrcatConfigReader::new(std::io::BufReader::new(file).lines());
+    Some(reader.collect())
 }
 
 /// Load and parse a grcat conf file. Returns empty vec on any error
@@ -206,94 +276,83 @@ pub fn load_grcat_config<T: AsRef<str>>(filename: T) -> Vec<GrcatConfigEntry> {
     Vec::new()
 }
 
-/// Configuration file paths in priority order.
-/// The program searches these paths to find grc.conf (or rgrc.conf) which maps
-/// commands to their colorization profiles. Paths prefixed with ~ are expanded using shellexpand.
-/// Typical flow: try ~/.grc first (user config), then system-wide configs (/etc/grc.conf).
-const CONFIG_PATHS: &[&str] = &[
-    "etc/rgrc.conf", // Development mode: relative to project root when develop with cargo run
-    "~/.rgrc",
-    "~/.config/rgrc/rgrc.conf",
-    "/usr/local/etc/rgrc.conf",
-    "/etc/rgrc.conf",
-    "~/.grc",
-    "~/.config/grc/grc.conf",
-    "/usr/local/etc/grc.conf",
-    "/etc/grc.conf",
-];
-
-/// Load colorization rules for a given pseudo-command by searching all configuration paths.
+/// Load colorization rules for a given pseudo-command by searching all
+/// configuration paths. The search stops at the first mapper file that yields
+/// rules. Priority: user mapper (`$XDG_CONFIG_HOME/rgrc/rgrc.conf`), the
+/// embedded mapper (its conf files still resolve disk paths first), then the
+/// remaining mapper paths ending with legacy grc locations.
 ///
-/// This function iterates through the predefined CONFIG_PATHS, attempting to load
-/// colorization rules for the specified pseudo-command from each configuration file.
-/// **The search stops at the first file that contains matching rules.**
-///
-/// # Priority Resolution
-///
-/// Configuration files are searched in priority order:
-/// 1. User configs (`~/.rgrc`, `~/.config/rgrc/rgrc.conf`) checked first
-/// 2. System configs (`/etc/rgrc.conf`, `/usr/local/etc/rgrc.conf`) as fallback
-/// 3. Legacy grc configs checked last for backward compatibility
-///
-/// # Arguments
-///
-/// * `pseudo_command` - The command string to match against configuration rules
-///   (e.g., "ping", "ls", "curl")
-///
-/// # Returns
-///
-/// A vector of `GrcatConfigEntry` containing all colorization rules that apply
-/// to the given pseudo-command from the **first config file containing matches**.
-///
-/// # Examples
-///
-/// ```ignore
-/// let rules = load_rules_for_command("ping");
-/// // Now rules contains all colorization rules for ping from the first matching config file
-/// ```
-#[allow(dead_code)]
+/// * `pseudo_command` - the command string to match, including arguments
+///   (e.g. "ping", "df -h"); a second pass matches the bare command name
 pub fn load_rules_for_command(pseudo_command: &str) -> Vec<GrcatConfigEntry> {
-    // Always prioritize user config first
-    let user_config_path = "~/.config/rgrc/rgrc.conf";
-    let expanded_user_config = expand_tilde(user_config_path);
-    let rules = load_config(&expanded_user_config, pseudo_command);
+    // Always prioritize the user mapper
+    let user_config = xdg_config_home().join("rgrc/rgrc.conf");
+    let rules = load_config(&user_config.to_string_lossy(), pseudo_command);
     if !rules.is_empty() {
         return rules;
     }
 
-    // then try embedded configs directly from memory
+    // embedded mapper; the conf files it references still resolve user
+    // paths on disk before falling back to the embedded copies
     #[cfg(feature = "embed-configs")]
-    {
-        let cursor = std::io::Cursor::new(EMBEDDED_GRC_CONF);
-        let reader = GrcConfigReader::new(std::io::BufReader::new(cursor).lines());
-        for (re, config_file) in reader {
-            if re.is_match(pseudo_command) {
-                if std::env::var_os("RGRC_DEBUG").is_some() {
-                    eprintln!(
-                        "rgrc: embedded matched pattern '{}' -> {}",
-                        re.as_str(),
-                        config_file
-                    );
-                }
-                if let Some(entries) = parse_embedded_conf(&config_file) {
-                    return entries;
-                }
-            }
-        }
+    if let Some(rules) = load_embedded(pseudo_command) {
+        return rules;
     }
 
-    for config_path in CONFIG_PATHS {
-        if *config_path == "~/.config/rgrc/rgrc.conf" {
+    for config_path in config_paths() {
+        if config_path == user_config {
             continue;
         }
-        let expanded_path = expand_tilde(config_path);
-        let rules = load_config(&expanded_path, pseudo_command);
+        let rules = load_config(&config_path.to_string_lossy(), pseudo_command);
         if !rules.is_empty() {
             return rules;
         }
     }
 
     Vec::new()
+}
+
+/// Rules for an explicitly requested config (`-c NAME`): NAME is first tried
+/// as a pseudo-command against the mappers, then directly as a conf file name
+/// ("df" resolves to conf.df; "conf.df" and paths are used as-is).
+pub fn load_rules_for_config(name: &str) -> Vec<GrcatConfigEntry> {
+    let rules = load_rules_for_command(name);
+    if !rules.is_empty() {
+        return rules;
+    }
+
+    let conf = if name.starts_with("conf.") || name.contains('/') {
+        name.to_string()
+    } else {
+        format!("conf.{}", name)
+    };
+    conf_rules(&conf)
+}
+
+#[cfg(feature = "embed-configs")]
+fn load_embedded(pseudo_command: &str) -> Option<Vec<GrcatConfigEntry>> {
+    let cursor = std::io::Cursor::new(EMBEDDED_GRC_CONF);
+    let reader = GrcConfigReader::new(std::io::BufReader::new(cursor).lines());
+    let patterns: Vec<_> = reader.collect();
+
+    let cmd_name = pseudo_command
+        .split_whitespace()
+        .next()
+        .unwrap_or(pseudo_command);
+    let conf = patterns
+        .iter()
+        .find(|(re, _)| re.is_match(pseudo_command))
+        .or_else(|| patterns.iter().find(|(re, _)| re.is_match(cmd_name)))
+        .map(|(_, c)| c.clone())?;
+    if std::env::var_os("RGRC_DEBUG").is_some() {
+        eprintln!(
+            "rgrc: embedded matched conf '{}' for '{}'",
+            conf, pseudo_command
+        );
+    }
+
+    let rules = conf_rules(&conf);
+    if rules.is_empty() { None } else { Some(rules) }
 }
 
 #[cfg(test)]
@@ -527,37 +586,72 @@ mod lib_test {
         assert!(has_system, "System config should contain SYSTEM pattern");
     }
 
+    // env-sensitive checks in one test: tests share one process and run in
+    // parallel, so HOME/XDG mutations must not interleave with each other
     #[test]
-    fn test_expand_tilde() {
-        // Test with valid HOME environment variable
+    fn config_resolution() {
+        use tempfile::TempDir;
+
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let td = TempDir::new().expect("create tempdir");
+        let rgrc_dir = td.path().join("rgrc");
+        std::fs::create_dir_all(&rgrc_dir).expect("create rgrc dir");
         unsafe {
-            std::env::set_var("HOME", "/home/testuser");
+            std::env::set_var("XDG_CONFIG_HOME", td.path());
         }
 
-        // Normal tilde expansion
-        assert_eq!(expand_tilde("~/Documents"), "/home/testuser/Documents");
-        assert_eq!(expand_tilde("~/"), "/home/testuser/");
-        assert_eq!(expand_tilde("~"), "~");
+        // XDG_CONFIG_HOME respected and user conf overrides the embedded copy
+        std::fs::write(rgrc_dir.join("rgrc.conf"), "^df(\\s|$)\nconf.df\n").unwrap();
+        std::fs::write(rgrc_dir.join("conf.df"), "regexp=USERDF\ncolours=green\n").unwrap();
+        let has_user_df = |cmd: &str| {
+            load_rules_for_command(cmd)
+                .iter()
+                .any(|r| r.regex.as_str().contains("USERDF"))
+        };
+        assert!(has_user_df("df"));
+        assert!(has_user_df("df -h"));
 
-        // No tilde should be unchanged
-        assert_eq!(expand_tilde("/absolute/path"), "/absolute/path");
-        assert_eq!(expand_tilde("relative/path"), "relative/path");
-        assert_eq!(expand_tilde(""), "");
+        // second pass: `^df$` also matches "df -h" via the bare command name
+        std::fs::write(rgrc_dir.join("rgrc.conf"), "^df$\nconf.df\n").unwrap();
+        assert!(has_user_df("df -h"));
 
-        // Tilde not at start should be unchanged
-        assert_eq!(expand_tilde("path~/to/file"), "path~/to/file");
-        assert_eq!(expand_tilde("path~"), "path~");
+        // explicit config lookup: name, conf.NAME, both resolve to user rules
+        assert!(
+            load_rules_for_config("df")
+                .iter()
+                .any(|r| r.regex.as_str().contains("USERDF"))
+        );
+        assert!(
+            load_rules_for_config("conf.df")
+                .iter()
+                .any(|r| r.regex.as_str().contains("USERDF"))
+        );
 
-        // Test without HOME environment variable
-        unsafe {
-            std::env::remove_var("HOME");
+        // embedded fallback still works once the user mapper is gone
+        std::fs::remove_file(rgrc_dir.join("rgrc.conf")).unwrap();
+        std::fs::remove_file(rgrc_dir.join("conf.df")).unwrap();
+        #[cfg(feature = "embed-configs")]
+        assert!(!load_rules_for_command("df -h").is_empty());
+
+        if let Some(x) = prev_xdg {
+            unsafe {
+                std::env::set_var("XDG_CONFIG_HOME", x);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("XDG_CONFIG_HOME");
+            }
         }
-        assert_eq!(expand_tilde("~/Documents"), "~/Documents");
-        assert_eq!(expand_tilde("/absolute/path"), "/absolute/path");
 
-        // Restore HOME for other tests
+        // dev share/ is opt-in via RGRC_DEV_SHARE
+        assert!(!resource_paths().iter().any(|p| p == Path::new("share")));
         unsafe {
-            std::env::set_var("HOME", "/home/testuser");
+            std::env::set_var("RGRC_DEV_SHARE", "1");
         }
+        let first = resource_paths().first().expect("non-empty").clone();
+        unsafe {
+            std::env::remove_var("RGRC_DEV_SHARE");
+        }
+        assert_eq!(first, PathBuf::from("share"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use rgrc::{
     buffer::LineBufferedWriter,
     colorizer::colorize_regex as colorize,
     grc::GrcatConfigEntry,
-    load_rules_for_command,
+    load_rules_for_command, load_rules_for_config,
     utils::{
         SUPPORTED_COMMANDS, command_exists, set_process_title,
         should_use_colorization_for_command_supported,
@@ -34,6 +34,67 @@ fn handle_io_error(e: std::io::Error) -> Result<(), Box<dyn std::error::Error>> 
         std::process::exit(0);
     }
     Err(Box::new(e))
+}
+
+// stdin-to-stdout passthrough; `ok` is the exit code on success, `err` on copy error
+fn copy_stdin(ok: i32, err: i32) -> ! {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut reader = io::BufReader::new(stdin.lock());
+    let mut writer = io::BufWriter::new(stdout.lock());
+    let res = io::copy(&mut reader, &mut writer);
+    let _ = writer.flush();
+    match res {
+        Ok(_) => std::process::exit(ok),
+        Err(_) => std::process::exit(err),
+    }
+}
+
+// grcat-style stdin filter for `rgrc -c NAME` without a trailing command
+fn filter_stdin(config_name: &str, color_mode: ColorMode) -> ! {
+    let stdout_is_terminal = io::stdout().is_terminal();
+    let should_colorize = match color_mode {
+        ColorMode::Off => false,
+        ColorMode::On => true,
+        ColorMode::Auto => stdout_is_terminal,
+    };
+
+    if !should_colorize {
+        copy_stdin(0, 0);
+    }
+
+    let rules: Vec<GrcatConfigEntry> = load_rules_for_config(config_name);
+    if rules.is_empty() {
+        eprintln!(
+            "Error: Failed to load rules for config '{}': No matching rules found",
+            config_name
+        );
+        copy_stdin(0, 1);
+    }
+
+    let stdin = io::stdin();
+    let mut buffered_stdin = io::BufReader::with_capacity(64 * 1024, stdin.lock());
+    let mut buffered_stdout = io::BufWriter::with_capacity(64 * 1024, io::stdout());
+    let mut line_buffered_writer = LineBufferedWriter::new(&mut buffered_stdout);
+
+    if let Err(e) = colorize(
+        &mut buffered_stdin,
+        &mut line_buffered_writer,
+        rules.as_slice(),
+    ) && let Err(e) = handle_box_error(e)
+    {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+
+    if let Err(e) = buffered_stdout.flush()
+        && let Err(e) = handle_io_error(e)
+    {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+
+    std::process::exit(0);
 }
 
 // Use mimalloc for faster memory allocation (reduces startup overhead)
@@ -120,88 +181,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(0);
     }
 
-    // If --config is specified, read from stdin and colorize using the specified config
-    if let Some(ref config_name) = args.config {
-        let color_mode = args.color;
-
-        // Detect if stdout is a terminal (TTY)
-        let stdout_is_terminal = io::stdout().is_terminal();
-
-        // Determine if we should colorize based on color mode and TTY status
-        let should_colorize = match color_mode {
-            ColorMode::Off => false,
-            ColorMode::On => true,
-            ColorMode::Auto => stdout_is_terminal,
-        };
-
-        if !should_colorize {
-            // Just pass through stdin to stdout without coloring
-            let stdin = io::stdin();
-            let stdout = io::stdout();
-            let mut reader = io::BufReader::new(stdin.lock());
-            let mut writer = io::BufWriter::new(stdout.lock());
-            match io::copy(&mut reader, &mut writer) {
-                Ok(_) => {
-                    let _ = writer.flush();
-                    std::process::exit(0);
-                }
-                Err(e) => {
-                    if e.kind() != std::io::ErrorKind::BrokenPipe {
-                        eprintln!("Error copying stdin to stdout: {}", e);
-                    }
-                    let _ = writer.flush();
-                    std::process::exit(0);
-                }
-            }
-        }
-
-        // Load colorization rules for the specified config
-        let rules: Vec<GrcatConfigEntry> = load_rules_for_command(config_name);
-
-        if rules.is_empty() {
-            // No rules found, just pass through
-            let stdin = io::stdin();
-            let stdout = io::stdout();
-            let mut reader = io::BufReader::new(stdin.lock());
-            let mut writer = io::BufWriter::new(stdout.lock());
-            match io::copy(&mut reader, &mut writer) {
-                Ok(_) => {
-                    let _ = writer.flush();
-                    std::process::exit(0);
-                }
-                Err(e) => {
-                    if e.kind() != std::io::ErrorKind::BrokenPipe {
-                        eprintln!(
-                            "Error: Failed to load rules for config '{}': No matching rules found",
-                            config_name
-                        );
-                    }
-                    let _ = writer.flush();
-                    std::process::exit(1);
-                }
-            }
-        }
-
-        // Read from stdin and colorize
-        let stdin = io::stdin();
-        let mut buffered_stdin = io::BufReader::with_capacity(64 * 1024, stdin.lock());
-        let mut buffered_stdout = io::BufWriter::with_capacity(64 * 1024, io::stdout());
-        let mut line_buffered_writer = LineBufferedWriter::new(&mut buffered_stdout);
-
-        if let Err(e) = colorize(
-            &mut buffered_stdin,
-            &mut line_buffered_writer,
-            rules.as_slice(),
-        ) {
-            handle_box_error(e)?;
-        }
-
-        // Flush buffered output
-        if let Err(e) = buffered_stdout.flush() {
-            handle_io_error(e)?;
-        }
-
-        std::process::exit(0);
+    // --config without a command: grcat-style stdin filter
+    // --config with a command: run the command and colorize its output (#23)
+    if let Some(ref config_name) = args.config
+        && args.command.is_empty()
+    {
+        filter_stdin(config_name, args.color);
     }
 
     if args.command.is_empty() {
@@ -209,8 +194,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
 
-    // Apply color mode setting
-    let color_mode = args.color;
+    let explicit_config = args.config.as_deref();
     let command_name = args.command.first().unwrap();
 
     // Update process title to show the wrapped command instead of "rgrc"
@@ -220,13 +204,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Detect if stdout is a terminal (TTY)
     let stdout_is_terminal = io::stdout().is_terminal();
 
-    // Determine if we should colorize based on color mode and TTY status
-    let should_colorize = match color_mode {
+    // An explicit -c config bypasses the supported-commands whitelist and
+    // the pseudo-command exclusions: the user asked for this config
+    let eligible =
+        explicit_config.is_some() || should_use_colorization_for_command_supported(command_name);
+    let should_colorize = match args.color {
         ColorMode::Off => false,
-        ColorMode::On => should_use_colorization_for_command_supported(command_name),
-        ColorMode::Auto => {
-            stdout_is_terminal && should_use_colorization_for_command_supported(command_name)
-        }
+        ColorMode::On => eligible,
+        ColorMode::Auto => stdout_is_terminal && eligible,
     };
 
     let pseudo_command = args.command.join(" ");
@@ -234,13 +219,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // check pseudo-command exclusions before loading rules so bare `rgrc ls`
     // skips coloring (ls colorizes its own output) while `rgrc ls -l` does not.
     let should_colorize = if should_colorize {
-        !rgrc::utils::pseudo_command_excluded(&pseudo_command)
+        explicit_config.is_some() || !rgrc::utils::pseudo_command_excluded(&pseudo_command)
     } else {
         false
     };
 
     let rules: Vec<GrcatConfigEntry> = if should_colorize {
-        load_rules_for_command(&pseudo_command)
+        match explicit_config {
+            Some(name) => load_rules_for_config(name),
+            None => load_rules_for_command(&pseudo_command),
+        }
     } else {
         Vec::new()
     };
@@ -249,10 +237,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::new(command_name);
     cmd.args(args.command.iter().skip(1));
 
-    // When not colorizing, let the child write directly to our stdout.
-    // Going through a pipe here only risks corrupting binary output (e.g.
-    // `docker save > file`, see #31) and adds copying overhead for no gain.
-    if !should_colorize {
+    // When not colorizing (or no rules resolved), let the child write
+    // directly to our stdout. Going through a pipe here only risks corrupting
+    // binary output (e.g. `docker save > file`, see #31) and adds copying
+    // overhead for no gain.
+    if !should_colorize || rules.is_empty() {
         cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::inherit());
 
@@ -276,18 +265,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 std::process::exit(1);
             }
         };
-        std::process::exit(ecode.code().unwrap_or(1));
-    }
-
-    // Final check: we need both the decision to colorize AND actual rules
-    // If no rules were loaded, skip colorization even if it was requested
-    if should_colorize && rules.is_empty() {
-        // No rules found, but we're piping - just pass through without coloring
-        // This handles the edge case where rule loading failed or returned empty
-        cmd.stdout(Stdio::inherit());
-        cmd.stderr(Stdio::inherit());
-        let mut child = cmd.spawn().expect("failed to spawn command");
-        let ecode = child.wait().expect("failed to wait on child");
         std::process::exit(ecode.code().unwrap_or(1));
     }
 

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -121,36 +121,41 @@ fn test_load_grcat_config_multiple_calls() {
 
 #[test]
 fn test_resource_paths_constant() {
-    let paths = rgrc::RESOURCE_PATHS;
+    let paths = rgrc::resource_paths();
 
-    assert!(!paths.is_empty(), "RESOURCE_PATHS should not be empty");
+    assert!(!paths.is_empty(), "resource_paths() should not be empty");
 
-    let has_user_paths = paths.iter().any(|p| p.contains("~"));
+    let has_xdg_config = paths.iter().any(|p| p.ends_with("rgrc"));
     let has_system_paths = paths.iter().any(|p| p.starts_with("/"));
+    let has_grc_compat = paths.iter().any(|p| p.ends_with("grc"));
 
-    assert!(has_user_paths, "Should contain user paths (~)");
+    assert!(has_xdg_config, "Should contain rgrc paths");
     assert!(has_system_paths, "Should contain system paths (/)");
+    assert!(has_grc_compat, "Should contain grc compat paths");
 }
 
 #[test]
 fn test_resource_paths_no_empty_entries() {
-    let paths = rgrc::RESOURCE_PATHS;
+    let paths = rgrc::resource_paths();
 
     for path in paths {
         assert!(
-            !path.is_empty(),
-            "RESOURCE_PATHS should not contain empty entries"
+            !path.as_os_str().is_empty(),
+            "resource_paths() should not contain empty entries"
         );
     }
 }
 
 #[test]
 fn test_resource_paths_valid_format() {
-    let paths = rgrc::RESOURCE_PATHS;
+    let paths = rgrc::resource_paths();
 
     for path in paths {
-        let valid = path.starts_with('~') || path.starts_with('/') || path == &"share";
-        assert!(valid, "Invalid path format: {}", path);
+        assert!(
+            !path.to_string_lossy().contains('~'),
+            "Paths should be tilde-expanded: {}",
+            path.display()
+        );
     }
 }
 

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -152,7 +152,7 @@ fn test_resource_paths_valid_format() {
 
     for path in paths {
         assert!(
-            !path.to_string_lossy().contains('~'),
+            !path.to_string_lossy().starts_with('~'),
             "Paths should be tilde-expanded: {}",
             path.display()
         );

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -248,6 +248,59 @@ mod embed_configs_tests {
         );
     }
 
+    // ~/.rgrc mapping wins over the embedded mapper (review on #34)
+    #[test]
+    fn test_legacy_mapper_overrides_embedded() {
+        let _guard = HOME_LOCK.lock().expect("HOME_LOCK mutex poisoned");
+        let td = TempDir::new().expect("create tempdir");
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let xdg_empty = td.path().join("xdgempty");
+        std::fs::create_dir_all(&xdg_empty).expect("create empty xdg dir");
+
+        unsafe {
+            std::env::set_var("HOME", td.path());
+            std::env::set_var("XDG_CONFIG_HOME", &xdg_empty);
+        }
+
+        std::fs::write(td.path().join(".rgrc"), "^df(\\s|$)\nconf.legacydf\n").unwrap();
+        let conf_dir = xdg_empty.join("rgrc");
+        std::fs::create_dir_all(&conf_dir).expect("create rgrc dir");
+        std::fs::write(
+            conf_dir.join("conf.legacydf"),
+            "regexp=LEGACYDF\ncolours=green\n",
+        )
+        .unwrap();
+
+        let used_legacy = rgrc::load_rules_for_command("df -h")
+            .iter()
+            .any(|r| r.regex.as_str().contains("LEGACYDF"));
+
+        if let Some(h) = prev_home {
+            unsafe {
+                std::env::set_var("HOME", h);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("HOME");
+            }
+        }
+        if let Some(x) = prev_xdg {
+            unsafe {
+                std::env::set_var("XDG_CONFIG_HOME", x);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("XDG_CONFIG_HOME");
+            }
+        }
+
+        assert!(
+            used_legacy,
+            "~/.rgrc mapping should win over the embedded mapper"
+        );
+    }
+
     #[test]
     fn test_embed_configs_grcat_filesystem_priority() {
         let mut temp_conf = NamedTempFile::new().unwrap();

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -443,4 +443,54 @@ mod cli_integration_tests {
             "Output should not contain ANSI escape codes when piped to a non-TTY"
         );
     }
+
+    // `rgrc -c NAME COMMAND` runs the command instead of blocking on stdin (#23)
+    #[test]
+    fn config_mode_with_command_executes() {
+        let output = Command::new(env!("CARGO_BIN_EXE_rgrc"))
+            .args([
+                "--color=on",
+                "-c",
+                "ping",
+                "echo",
+                "64 bytes from 192.168.1.1: icmp_seq=1 ttl=64 time=0.5 ms",
+            ])
+            .output()
+            .expect("failed to run rgrc");
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("64 bytes from"));
+        assert!(stdout.contains("\x1b["));
+    }
+
+    // exit code of the child propagates in -c exec mode
+    #[test]
+    fn config_mode_with_command_propagates_exit_code() {
+        let output = Command::new(env!("CARGO_BIN_EXE_rgrc"))
+            .args(["-c", "ping", "sh", "-c", "exit 42"])
+            .output()
+            .expect("failed to run rgrc");
+
+        assert_eq!(output.status.code(), Some(42));
+    }
+
+    // -c accepts a bare conf name too ("df" and "conf.df" both work)
+    #[test]
+    fn config_mode_accepts_conf_name() {
+        let df_line = "/dev/sda1 100G 50G 50G 50% /";
+        let out_name = Command::new(env!("CARGO_BIN_EXE_rgrc"))
+            .args(["--color=on", "-c", "df", "echo", df_line])
+            .output()
+            .expect("failed to run rgrc");
+        let out_conf = Command::new(env!("CARGO_BIN_EXE_rgrc"))
+            .args(["--color=on", "-c", "conf.df", "echo", df_line])
+            .output()
+            .expect("failed to run rgrc");
+
+        assert!(out_name.status.success());
+        assert!(out_conf.status.success());
+        assert_eq!(out_name.stdout, out_conf.stdout);
+        assert!(String::from_utf8_lossy(&out_name.stdout).contains("\x1b["));
+    }
 }


### PR DESCRIPTION
Closes #23.

The analysis in #23 by @sedlund drove these changes; a review from @sedlund
would be very welcome.

## What changed

- **User configs override embedded ones again.** The embedded fallback fired
  at the first resource-path miss, so any shipped conf.* silently won over
  ~/.config/rgrc/conf.df. Embedded configs are now the last resort, searched
  only after all disk paths fail.
- **`rgrc -c NAME COMMAND [ARGS...]` runs the command** instead of blocking
  on stdin. `-c NAME` without a command still filters stdin like grcat.
  `-c` also accepts conf file names: `df` and `conf.df` both work.
- **XDG base directories are honored.** XDG_CONFIG_HOME, XDG_DATA_HOME,
  XDG_CONFIG_DIRS and XDG_DATA_DIRS with their spec defaults; grc compat
  paths are kept.
- **Dev paths are opt-in.** `share/` and `etc/rgrc.conf` relative to the cwd
  are only searched when RGRC_DEV_SHARE is set, so a stray share/ directory
  can no longer shadow user configs.
- **Two-pass matching.** rgrc.conf patterns match the full command line
  first, then the bare command name, so `^df$` also matches `df -h`.
  Patterns that require arguments keep working.
- **conf.df**: dropped the unnecessary lookahead in the first rule so it
  stays on the fast regex path.

An explicit `-c` config bypasses the supported-commands whitelist and the
pseudo-command exclusions: the user asked for that config.

## Testing

- make test and make check pass
- new lib test covers resolution ordering, two-pass matching, XDG lookup
  and the RGRC_DEV_SHARE gate; 3 new integration tests cover -c exec mode
  and exit-code propagation
- manual runs: user conf.df override, `df -h | rgrc -c df`,
  `rgrc -c df df -h`, XDG_CONFIG_HOME lookup, RGRC_DEV_SHARE gating
- the df fuzzer from #24 passes against the new conf.df: 2000 fuzzed
  WSL-ish lines across 10 seeds, no panics, no dropped lines, correct
  coloring

## Notes

Distro builds with --no-default-features are unaffected; the XDG search
order applies to both.
