### PR TITLE
fix: panic batch and df colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix: no panic on closed stdout for --aliases/--completions/--version/--help
+- fix: multibyte command names no longer panic the process title truncation
+- fix: report 128+signal when the wrapped command is killed by a signal
+- fix(df): sizes use one neutral color; red is reserved for high Use% (#22)
+
 - fix: disk mapper and conf files now override the embedded ones; embedded is the last resort for both (#23)
 - feat: `rgrc -c NAME COMMAND [ARGS...]` runs the command instead of blocking on stdin; `-c` also accepts conf file names like `conf.df` (#23)
 - feat: honor XDG_CONFIG_HOME/XDG_DATA_HOME/XDG_CONFIG_DIRS/XDG_DATA_DIRS for config lookup (#23)

--- a/share/conf.df
+++ b/share/conf.df
@@ -3,21 +3,19 @@
 regexp=^(\/[-\w\d.]+)+\s
 colours=blue,bold blue
 ======
-# Size 'K'
+# Sizes: one neutral color; the unit scale says nothing about disk health,
+# red is reserved for the Use% thresholds below (#22)
 regexp=\s\d*[.,]?\d(K|B)i?\s|\b\d{1,3}\b
-colours=green
+colours=cyan
 ======
-# Size 'M'
 regexp=\s\d*[.,]?\dMi?\s|\b\d{4,6}\b
-colours=yellow
+colours=cyan
 ======
-# Size 'G'
 regexp=\s\d*[.,]?\dGi?\s|\b\d{7,9}\b
-colours=red
+colours=cyan
 ======
-# Size 'T'
 regexp=\s\d*[.,]?\dTi?\s|\b\d{10,12}\b
-colours=bold red
+colours=cyan
 ======
 # Mounted on
 regexp=\/$|(\/[-\w\d. ]+)+$

--- a/src/args.rs
+++ b/src/args.rs
@@ -238,29 +238,51 @@ end
 
 /// Print help message to stdout
 fn print_help() {
-    println!("Rusty Generic Colouriser");
-    println!();
-    println!("Usage: rgrc [OPTIONS] COMMAND [ARGS...]");
-    println!();
-    println!("Options:");
-    println!("  --color, --colour    Override color output (on|off|auto)");
-    println!("  --aliases            Output shell aliases for available binaries");
-    println!("  --all-aliases        Output all shell aliases");
-    println!("  --except CMD,..      Exclude commands from alias generation");
-    println!("  --completions SHELL  Print shell completion script for SHELL (bash|zsh|fish|ash)");
+    use std::fmt::Write as _;
+
+    let mut s = String::new();
+    let _ = writeln!(
+        s,
+        "Rusty Generic Colouriser\n\nUsage: rgrc [OPTIONS] COMMAND [ARGS...]\n\nOptions:"
+    );
+    let _ = writeln!(
+        s,
+        "  --color, --colour    Override color output (on|off|auto)"
+    );
+    let _ = writeln!(
+        s,
+        "  --aliases            Output shell aliases for available binaries"
+    );
+    let _ = writeln!(s, "  --all-aliases        Output all shell aliases");
+    let _ = writeln!(
+        s,
+        "  --except CMD,..      Exclude commands from alias generation"
+    );
+    let _ = writeln!(
+        s,
+        "  --completions SHELL  Print shell completion script for SHELL (bash|zsh|fish|ash)"
+    );
     #[cfg(feature = "embed-configs")]
-    println!("  --config, -c NAME    Explicit config (df or conf.df); with a COMMAND runs it");
-    println!("  --help, -h           Show this help message");
-    println!("  --version, -V        Show installed rgrc version and exit");
-    println!();
-    println!("Examples:");
-    println!("  rgrc ping -c 4 google.com");
-    println!("  rgrc --color=off ls -la");
-    println!("  rgrc --aliases");
-    println!();
-    println!("  df -h | rgrc -c df          # Apply df config to piped input");
-    println!("  rgrc -c df df -h            # Run df -h and colorize with conf.df");
-    println!("  rgrc -c conf.myapp myapp    # Use an explicit conf file");
+    let _ = writeln!(
+        s,
+        "  --config, -c NAME    Explicit config (df or conf.df); with a COMMAND runs it"
+    );
+    let _ = writeln!(s, "  --help, -h           Show this help message");
+    let _ = writeln!(
+        s,
+        "  --version, -V        Show installed rgrc version and exit"
+    );
+    let _ = writeln!(
+        s,
+        "\nExamples:\n  rgrc ping -c 4 google.com\n  rgrc --color=off ls -la\n  rgrc --aliases"
+    );
+    let _ = writeln!(
+        s,
+        "\n  df -h | rgrc -c df          # Apply df config to piped input\n  rgrc -c df df -h            # Run df -h and colorize with conf.df\n  rgrc -c conf.myapp myapp    # Use an explicit conf file"
+    );
+
+    // single write with the error ignored: `rgrc --help | head` must not panic
+    let _ = std::io::Write::write_all(&mut std::io::stdout(), s.as_bytes());
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,7 @@ use rgrc::{
     colorizer::colorize_regex as colorize,
     grc::GrcatConfigEntry,
     load_rules_for_command, load_rules_for_config,
-    utils::{
-        SUPPORTED_COMMANDS, command_exists, set_process_title,
-        should_use_colorization_for_command_supported,
-    },
+    utils::{set_process_title, should_use_colorization_for_command_supported, write_aliases},
 };
 
 use std::io::{self, IsTerminal, Write};
@@ -132,9 +129,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    // Handle --version flag first: print version and exit
+    // Handle --version flag first: print version and exit.
+    // write-and-ignore instead of println!: a closed pipe must not panic
     if args.show_version {
-        println!("rgrc {}", env!("CARGO_PKG_VERSION"));
+        let _ = writeln!(io::stdout().lock(), "rgrc {}", env!("CARGO_PKG_VERSION"));
         std::process::exit(0);
     }
 
@@ -142,7 +140,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(shell) = args.show_completions.as_deref() {
         match get_completion_script(shell) {
             Some(script) => {
-                print!("{}", script);
+                let _ = write!(io::stdout().lock(), "{}", script);
                 std::process::exit(0);
             }
             None => {
@@ -167,17 +165,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .flat_map(|s| s.split(',').map(|p| p.trim().to_string()))
             .collect();
 
-        // Curated list of commands known to work well with grc
-        for cmd in SUPPORTED_COMMANDS {
-            // Output a shell alias if:
-            // 1. The command is not in the exclude list, AND
-            // 2. Either we're generating all aliases (--all-aliases) OR the command exists in PATH (which::which)
-            if !except_set.contains(cmd as &str) && (args.show_all_aliases || command_exists(cmd)) {
-                // plain alias for every command; piping to less in the alias
-                // breaks trailing args like `journalctl -f` (#32)
-                println!("alias {}='{} {}'", cmd, grc, cmd);
-            }
-        }
+        let mut out = io::BufWriter::new(io::stdout().lock());
+        let _ = write_aliases(&mut out, &grc, args.show_all_aliases, &except_set);
+        let _ = out.flush();
         std::process::exit(0);
     }
 
@@ -265,7 +255,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 std::process::exit(1);
             }
         };
-        std::process::exit(ecode.code().unwrap_or(1));
+        std::process::exit(child_exit_code(&ecode));
     }
 
     // Only pipe stdout when colorization is actually needed
@@ -310,5 +300,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Wait for the spawned command to complete and propagate its exit code.
     let ecode = child.wait().expect("failed to wait on child");
-    std::process::exit(ecode.code().expect("need an exit code"));
+    std::process::exit(child_exit_code(&ecode));
+}
+
+/// Exit status to propagate: the child's code, or 128+signal like a shell
+/// reports when the child was killed.
+fn child_exit_code(status: &std::process::ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        128 + status.signal().unwrap_or(1)
+    }
+    #[cfg(not(unix))]
+    {
+        1
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,9 +20,14 @@ pub fn set_process_title(title: &str) {
     {
         use std::io::Write;
 
-        // 1. Update /proc/self/comm (short name, max 15 bytes)
+        // 1. Update /proc/self/comm (short name, max 15 bytes).
+        //    Byte 15 can fall inside a multibyte char; back up to the boundary.
         let truncated = if title.len() > 15 {
-            &title[..15]
+            let mut end = 15;
+            while !title.is_char_boundary(end) {
+                end -= 1;
+            }
+            &title[..end]
         } else {
             title
         };
@@ -230,6 +235,27 @@ pub const SUPPORTED_COMMANDS: &[&str] = &[
     "iostat",
 ];
 
+/// Write `alias CMD='rgrc CMD'` lines for supported commands.
+///
+/// Stops at the first write error (a closed pipe like `rgrc --aliases | head`)
+/// and returns it; callers ignore it so the process exits quietly instead of
+/// panicking the way `println!` does on EPIPE.
+pub fn write_aliases<W: std::io::Write>(
+    w: &mut W,
+    grc: &str,
+    all: bool,
+    except: &std::collections::HashSet<String>,
+) -> std::io::Result<()> {
+    for cmd in SUPPORTED_COMMANDS {
+        if !except.contains(cmd as &str) && (all || command_exists(cmd)) {
+            // plain alias for every command; piping to less in the alias
+            // breaks trailing args like `journalctl -f` (#32)
+            writeln!(w, "alias {}='{} {}'", cmd, grc, cmd)?;
+        }
+    }
+    Ok(())
+}
+
 /// Check if a command has colorization rules available (used for Always strategy)
 /// Return `true` when a command has shipped colorization rules (present in
 /// `SUPPORTED_COMMANDS`). This is a simple membership check used by the
@@ -298,6 +324,35 @@ pub fn pseudo_command_excluded(pseudo_command: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn alias_lines_and_except() {
+        let except: std::collections::HashSet<String> = ["ant".to_string()].into_iter().collect();
+        let mut out = Vec::new();
+        write_aliases(&mut out, "rgrc", true, &except).expect("vec writes cannot fail");
+
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("alias df='rgrc df'"));
+        assert!(!text.contains("alias ant="));
+    }
+
+    #[test]
+    fn aliases_stop_quietly_on_write_error() {
+        struct Failing;
+        impl std::io::Write for Failing {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("broken pipe"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let except = std::collections::HashSet::new();
+        let mut w = Failing;
+        // must return the error, not panic (println! would)
+        assert!(write_aliases(&mut w, "rgrc", true, &except).is_err());
+    }
 
     #[test]
     fn test_command_exists() {
@@ -396,7 +451,9 @@ mod tests {
 
     #[test]
     fn test_set_process_title() {
-        // On Linux, verify that writing to /proc/self/comm works
+        // On Linux, verify that writing to /proc/self/comm works.
+        // Multibyte case shares /proc/self/comm with this test: keep both
+        // here so the parallel writes cannot race each other.
         #[cfg(target_os = "linux")]
         {
             set_process_title("test_cmd");
@@ -415,6 +472,12 @@ mod tests {
                 .expect("should be able to read /proc/self/comm");
             assert_eq!(comm.trim().len(), 15);
             assert!(comm.trim().starts_with("this_is_a_very_"));
+
+            // byte 15 falls inside a multibyte char; cutting there used to panic
+            set_process_title("a日本語コマンド名前");
+            let comm = std::fs::read_to_string("/proc/self/comm")
+                .expect("should be able to read /proc/self/comm");
+            assert!(comm.trim().starts_with("a日本語コ"));
 
             // Restore process name
             set_process_title("test_set_proces");

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -493,4 +493,42 @@ mod cli_integration_tests {
         assert_eq!(out_name.stdout, out_conf.stdout);
         assert!(String::from_utf8_lossy(&out_name.stdout).contains("\x1b["));
     }
+
+    // a signal-killed child reports 128+signal instead of panicking
+    #[test]
+    #[cfg(unix)]
+    fn signal_death_reports_shell_style_code() {
+        for (sig, expected) in [(9, 137), (15, 143)] {
+            let output = Command::new(env!("CARGO_BIN_EXE_rgrc"))
+                .args(["-c", "ping", "sh", "-c", &format!("kill -{sig} $$")])
+                .output()
+                .expect("failed to run rgrc");
+
+            assert_eq!(output.status.code(), Some(expected));
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(!stderr.contains("panicked"));
+        }
+    }
+
+    // closed stdout must not panic the println! paths (rgrc --aliases | head)
+    #[test]
+    #[cfg(unix)]
+    fn no_panic_on_closed_stdout() {
+        let exe = env!("CARGO_BIN_EXE_rgrc");
+        for flag in ["--all-aliases", "--help", "--version"] {
+            let out = Command::new("sh")
+                .arg("-c")
+                .arg(format!(
+                    "{exe} {flag} 2>/tmp/rgrc_err.txt | head -1 >/dev/null"
+                ))
+                .output()
+                .expect("failed to run sh");
+            let stderr = std::fs::read_to_string("/tmp/rgrc_err.txt").unwrap_or_default();
+            assert!(
+                !stderr.contains("panicked"),
+                "{flag} panicked on closed stdout: {stderr}"
+            );
+            assert!(out.status.success());
+        }
+    }
 }


### PR DESCRIPTION
Fixes #22.

- no more panic on closed stdout: `rgrc --aliases | head` used to die with
  "failed printing to stdout: Broken pipe" (20/20 on master, 0/20 with the fix)
```bash
❯ rgrc --all-aliases | head
alias ant='rgrc ant'
alias blkid='rgrc blkid'
alias common='rgrc common'
alias curl='rgrc curl'
alias cvs='rgrc cvs'
alias df='rgrc df'
alias diff='rgrc diff'
alias dig='rgrc dig'
alias diskutil='rgrc diskutil'
alias dnf='rgrc dnf'

thread 'main' (283065) panicked at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Broken pipe (os error 32)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
- multibyte command names no longer panic the process title truncation
- a signal-killed child exits 128+signal like a shell, no panic
- df sizes use one neutral color; red stays reserved for high Use% (#22)
